### PR TITLE
Allow formula syntax

### DIFF
--- a/R/vioplotx.R
+++ b/R/vioplotx.R
@@ -59,12 +59,17 @@
 #' vioplotx(data_one, data_two, rnorm(200, 3, 0.5), rpois(200, 2.5),  rbinom(100, 10, 0.4), areaEqual=T, col=c("red", "orange", "green", "blue", "violet"), rectCol=c("palevioletred", "peachpuff", "lightgreen", "lightblue", "plum"), lineCol=c("red4", "orangered", "forestgreen", "royalblue", "mediumorchid"), border=c("red4", "orangered", "forestgreen", "royalblue", "mediumorchid"), names=c("data one", "data two", "data three", "data four", "data five"), main="data violin", xlab="data class", ylab="data read")
 #'
 vioplotx <-
-  function (x, ..., range = 1.5, h = NULL, ylim = NULL, names = NULL,
+  function (x, ..., data = NULL, range = 1.5, h = NULL, ylim = NULL, names = names(datas),
             horizontal = FALSE, col = "grey50", border = "black", lty = 1,
             lwd = 1, rectCol = "black", lineCol = "black", colMed = "white", pchMed = 19,
             at, add = FALSE, wex = 1, drawRect = TRUE, areaEqual=FALSE, main=NA, sub=NA, xlab=NA, ylab=NA)
   {
-    datas <- list(x, ...)
+    if (inherits(x, "formula")) {
+		  m <- model.frame(x, data = data)
+		  datas <- tapply(m[,1], m[,2], c, simplify = FALSE)
+	  } else {
+		  datas <- list(x, ...)
+	  }
     n <- length(datas)
     if (missing(at))
       at <- 1:n

--- a/R/vioplotx.R
+++ b/R/vioplotx.R
@@ -59,17 +59,18 @@
 #' vioplotx(data_one, data_two, rnorm(200, 3, 0.5), rpois(200, 2.5),  rbinom(100, 10, 0.4), areaEqual=T, col=c("red", "orange", "green", "blue", "violet"), rectCol=c("palevioletred", "peachpuff", "lightgreen", "lightblue", "plum"), lineCol=c("red4", "orangered", "forestgreen", "royalblue", "mediumorchid"), border=c("red4", "orangered", "forestgreen", "royalblue", "mediumorchid"), names=c("data one", "data two", "data three", "data four", "data five"), main="data violin", xlab="data class", ylab="data read")
 #'
 vioplotx <-
-  function (x, ..., data = NULL, range = 1.5, h = NULL, ylim = NULL, names = names(datas),
+  function (x, ..., data = NULL, range = 1.5, h = NULL, ylim = NULL, names = NULL,
             horizontal = FALSE, col = "grey50", border = "black", lty = 1,
             lwd = 1, rectCol = "black", lineCol = "black", colMed = "white", pchMed = 19,
             at, add = FALSE, wex = 1, drawRect = TRUE, areaEqual=FALSE, main=NA, sub=NA, xlab=NA, ylab=NA)
   {
     if (inherits(x, "formula")) {
-		  m <- model.frame(x, data = data)
-		  datas <- tapply(m[,1], m[,2], c, simplify = FALSE)
-	  } else {
-		  datas <- list(x, ...)
-	  }
+      m <- model.frame(x, data = data)
+      datas <- tapply(m[,1], m[,2], c, simplify = FALSE)
+      if (is.null(names)) names <- names(datas)
+    } else {
+      datas <- list(x, ...)
+    }
     n <- length(datas)
     if (missing(at))
       at <- 1:n


### PR DESCRIPTION
I think that's all that is needed...
It'll remain backwards-compatible, but allows `x` to be a formula:

``` r
vioplotx(Sepal.Length ~ Species, data = iris)
```

Also lazy eval of `names`, so user doesn't have to worry about that (if they don't want to) and they should match up ... and if they specify vectors (old way) `names = names(datas)` evaluates to `NULL` so it should work. 

**Disclaimer**: have not tested.
